### PR TITLE
chore: use matrix.os for test job runs-on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     needs: build
     if: (!cancelled()) && inputs.maven-test-run && ( !inputs.maven-single-run || needs.build.result == 'success' )
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
            **/target/**
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
     if: (!cancelled()) && inputs.maven-test-run && ( !inputs.maven-single-run || needs.build.result == 'success' )
     strategy:


### PR DESCRIPTION
## Summary

- Fix the CI test job `runs-on` to use `${{ matrix.os }}` instead of hardcoded `ubuntu-latest`, so that Windows and macOS matrix legs actually run on the intended OS instead of being duplicate Ubuntu runs.

This is a one-line fix in `.github/workflows/ci.yml`. The `os-matrix` input (defaulting to `[ "ubuntu-latest", "windows-latest", "macOS-latest" ]`) was already wired into the strategy matrix, but `runs-on` was ignoring it. `matrix.os` was only referenced in the uploaded artifact name.

The `build` job remains on `ubuntu-latest` since it is a single pre-cache step without an OS matrix.

Ref: maveniverse/scalpel#50 (item 4)

## Test plan

- [ ] Verify the PR's own CI runs the test matrix on all three OSes (check the GitHub Actions UI for distinct runners)
- [ ] Confirm cache restoration works cross-OS (the build job caches on Ubuntu; test jobs restore on each OS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Continuous integration tests now run on each configured operating system in the test matrix, improving cross-platform validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->